### PR TITLE
Add option to --succeed-always 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,40 @@ repos:
         args: ['-j', 'MYJIRA', '-q']
 ```
 
+### Alert Without Blocking
+
+Alert developers to dangling TODOs without blocking commits. When using `--succeed-always`, the hook will always return exit code 0 (success), but by default pre-commit hides output from successful hooks. To ensure TODO violations are still visible, you should configure verbose output:
+
+**Recommended: Always show output (persistent configuration)**
+```yaml
+repos:
+  - repo: https://github.com/lasp/prevent-dangling-todos
+    hooks:
+      - id: prevent-dangling-todos
+        args: ['-j', 'MYJIRA', '--succeed-always']
+        verbose: true  # Always show output, even when hook succeeds
+```
+
+**Alternative: Show output only when needed (runtime flag)**
+```yaml
+repos:
+  - repo: https://github.com/lasp/prevent-dangling-todos
+    hooks:
+      - id: prevent-dangling-todos
+        args: ['-j', 'MYJIRA', '--succeed-always']
+```
+Then run with: `pre-commit run --verbose` or `git commit` (if you want to see violations occasionally)
+
+**When to use `--succeed-always`:**
+- You want to raise awareness about TODOs without blocking commits
+- You're implementing a gradual migration to enforced TODO references
+- You have a large codebase with existing TODOs and want visibility before enforcing
+
+**When to use normal mode (without `--succeed-always`):**
+- You want to strictly enforce TODO references (blocks commits until fixed)
+- You have a clean codebase or are starting fresh
+- You want to prevent any new dangling TODOs from being committed
+
 ## Configuration Options
 
 ### Command Line Arguments
@@ -61,6 +95,7 @@ repos:
 - `-j, --jira-prefix PREFIXES`: Jira project prefixes (comma-separated)
 - `-c, --comment-prefix PREFIXES`: Comment types to check (comma-separated)
 - `-q, --quiet`: Suppress decorative output
+- `--succeed-always`: Always exit with code 0, even when TODOs are found
 - `--version`: Show version information
 
 ### File Exclusions
@@ -111,11 +146,16 @@ TODO, FIXME, XXX, HACK, BUG, REVIEW, OPTIMIZE, REFACTOR
 1. **"Jira project prefix(es) must be specified"**
    - Ensure you provide either `-j/--jira-prefix` argument or `JIRA_PREFIX` environment variable
 
-2. **Comments not being detected**
+2. **TODO violations not showing when using `--succeed-always`**
+   - By default, pre-commit hides output from successful hooks
+   - **Solution**: Add `verbose: true` to your hook configuration, or use `pre-commit run --verbose`
+   - See the "Alert Without Blocking" section for examples
+
+3. **Comments not being detected**
    - Check that your comment format matches: `# TODO JIRA-123: Description`
    - Ensure the Jira prefix matches your configuration
 
-3. **False positives**
+4. **False positives**
    - Use `-c/--comment-prefix` to check only specific comment types
    - Consider using `-q/--quiet` mode in automated environments
 

--- a/prevent_dangling_todos/prevent_todos.py
+++ b/prevent_dangling_todos/prevent_todos.py
@@ -26,6 +26,8 @@ class TodoChecker:
         List of comment prefixes to check (e.g., TODO, FIXME)
     quiet : bool
         Whether to suppress decorative output
+    succeed_always : bool
+        Whether to always exit with code 0 even when violations are found
     exit_code : int
         Track exit code for violations (0 = success, 1 = violations found)
     comment_pattern : re.Pattern
@@ -39,6 +41,7 @@ class TodoChecker:
         jira_prefixes: Union[str, List[str]],
         comment_prefixes: Optional[List[str]] = None,
         quiet: bool = False,
+        succeed_always: bool = False,
     ):
         """
         Initialize the TodoChecker.
@@ -51,6 +54,8 @@ class TodoChecker:
             Comment prefixes to check (e.g., ["TODO", "FIXME"]). If None, uses default list.
         quiet : bool, optional
             If True, only output violations without decorative text or tips. Default is False.
+        succeed_always : bool, optional
+            If True, always exit with code 0 even when violations are found. Default is False.
         """
         # Always store as list internally
         if isinstance(jira_prefixes, str):
@@ -59,6 +64,7 @@ class TodoChecker:
             self.jira_prefixes = jira_prefixes
 
         self.quiet = quiet
+        self.succeed_always = succeed_always
         self.exit_code = 0
 
         # Comment prefixes that should require Jira references
@@ -207,4 +213,5 @@ class TodoChecker:
                     other_prefixes = ", ".join(self.jira_prefixes[1:])
                     print(f"   (Also valid: {other_prefixes})")
 
-        return self.exit_code
+        # Return 0 if succeed_always is True, otherwise return the actual exit code
+        return 0 if self.succeed_always else self.exit_code


### PR DESCRIPTION
This allows a user to configure the hook to always succeed even when dangling TODOs are found. This allows this hook to be effectively informational only without blocking commits.